### PR TITLE
Add test plan configuration and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+build/
+xcuserdata/
+DerivedData/
+.DS_Store

--- a/bikecheck.xcodeproj/project.pbxproj
+++ b/bikecheck.xcodeproj/project.pbxproj
@@ -108,6 +108,7 @@
 		A3E742922B46FDEE00C5191F /* Athlete.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Athlete.swift; sourceTree = "<group>"; usesTabs = 0; };
 		A3E742932B46FDEE00C5191F /* Activity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Activity.swift; sourceTree = "<group>"; };
 		A3E742942B46FDEE00C5191F /* Bike.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Bike.swift; sourceTree = "<group>"; };
+		A3F2D2872E1318A20079E9FA /* bikecheck.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = bikecheck.xctestplan; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -139,6 +140,7 @@
 		A365AFF42B44D34900FF712E = {
 			isa = PBXGroup;
 			children = (
+				A3F2D2872E1318A20079E9FA /* bikecheck.xctestplan */,
 				A365AFFF2B44D34900FF712E /* bikecheck */,
 				A365B0152B44D34A00FF712E /* bikecheckTests */,
 				A365B01F2B44D34A00FF712E /* bikecheckUITests */,

--- a/bikecheck.xcodeproj/xcshareddata/xcschemes/bikecheck.xcscheme
+++ b/bikecheck.xcodeproj/xcshareddata/xcschemes/bikecheck.xcscheme
@@ -27,12 +27,17 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      shouldAutocreateTestPlan = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:bikecheck.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
       <Testables>
          <TestableReference
             skipped = "NO"
-            parallelizable = "YES">
+            parallelizable = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "A365B0112B44D34A00FF712E"

--- a/bikecheck.xctestplan
+++ b/bikecheck.xctestplan
@@ -1,0 +1,36 @@
+{
+  "configurations" : [
+    {
+      "id" : "BB6ACD09-38BC-4DE5-83A5-9C59746551A7",
+      "name" : "Test Scheme Action",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:bikecheck.xcodeproj",
+      "identifier" : "A365AFFC2B44D34900FF712E",
+      "name" : "bikecheck"
+    }
+  },
+  "testTargets" : [
+    {
+      "parallelizable" : false,
+      "target" : {
+        "containerPath" : "container:bikecheck.xcodeproj",
+        "identifier" : "A365B0112B44D34A00FF712E",
+        "name" : "bikecheckTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:bikecheck.xcodeproj",
+        "identifier" : "A365B01B2B44D34A00FF712E",
+        "name" : "bikecheckUITests"
+      }
+    }
+  ],
+  "version" : 1
+}


### PR DESCRIPTION
- Add bikecheck.xctestplan for organized test execution
- Update Xcode project to reference test plan
- Configure scheme to use test plan with disabled parallelization
- Add gitignore for build artifacts and system files

🤖 Generated with [Claude Code](https://claude.ai/code)